### PR TITLE
Feature/rtk epochtime

### DIFF
--- a/mixmasta/download.py
+++ b/mixmasta/download.py
@@ -73,6 +73,7 @@ def download_and_clean(
     download_data_folder = f"{cdir}/{dirname}"
 
     test_if_exist = f"{download_data_folder}/{gadm_fn}"
+    print(test_if_exist)
     if os.path.exists(test_if_exist):
         print(f"{test_if_exist} already downloaded")
 

--- a/mixmasta/mixmasta.py
+++ b/mixmasta/mixmasta.py
@@ -221,7 +221,7 @@ def match_geo_names(admin: str, df: pd.DataFrame) -> pd.DataFrame:
 
         # Get list of admin1 values in df but not in gadm. Reduce list for country.           
         admin1_list = gadm[gadm.country==c]["admin1"].unique()    
-        if not admin1_list.any(None) and admin1_list != None:
+        if admin1_list is not None and all(admin1_list):
             unknowns = df[(df.country == c) & ~df.admin1.isin(admin1_list)].admin1.tolist()
             unknowns = [x for x in unknowns if pd.notnull(x) and x.strip()] # remove Nan
             for unk in unknowns:
@@ -231,7 +231,7 @@ def match_geo_names(admin: str, df: pd.DataFrame) -> pd.DataFrame:
 
         # Get list of admin2 values in df but not in gadm. Reduce list for country.           
         admin2_list = gadm[gadm.country==c ]["admin2"].unique()
-        if not admin2_list.any(None) and admin2_list != None:
+        if admin2_list is not None and all(admin2_list):
             unknowns = df[(df.country == c) & ~df.admin2.isin(admin2_list)].admin2.tolist()
             unknowns = [x for x in unknowns if pd.notnull(x) and x.strip()] # remove Nan
             for unk in unknowns:
@@ -242,7 +242,7 @@ def match_geo_names(admin: str, df: pd.DataFrame) -> pd.DataFrame:
         if admin =='admin3':
             # Get list of admin3 values in df but not in gadm. Reduce list for country.           
             admin3_list = gadm[gadm.country==c]["admin3"].unique()       
-            if not admin3_list.any(None) and admin3_list != None:
+            if admin3_list is not None and all(admin3_list):
                 unknowns = df[(df.country == c) & ~df.admin3.isin(admin3_list)].admin3.tolist()
                 unknowns = [x for x in unknowns if pd.notnull(x) and x.strip()] # remove Nan
                 for unk in unknowns:                
@@ -683,8 +683,8 @@ def process(fp: str, mp: str, admin: str, output_file: str):
     del(norm_str['type'])
     del(norm['type'])    
 
-    #print('\n', norm.head())
-    #print('\n', norm_str.tail())
+    print('\n', norm.head())
+    print('\n', norm_str.tail())
 
     norm.to_parquet(f"{output_file}.parquet.gzip", compression="gzip")
     if len(norm_str) > 0:

--- a/mixmasta/mixmasta.py
+++ b/mixmasta/mixmasta.py
@@ -452,11 +452,10 @@ def normalizer(df: pd.DataFrame, mapper: dict, admin: str) -> pd.DataFrame:
 
     # mapper is a dictionary of lists of dictionaries.
     
+    time_cols = [k['name'] for k in mapper['date'] if 'primary_date' in k and k['primary_date'] == True]
+    other_time_cols = [k['name'] for k in mapper['date'] if 'primary_date' not in k or k['primary_date'] == False]
     
-    time_cols = [k['name'] for k in mapper['date'] if k['primary_date'] == True]
-    other_time_cols = [k['name'] for k in mapper['date'] if k['primary_date'] == False]
-    
-    geo_cols = [k["name"] for k in mapper["geo"] if k["primary_geo"] == True]
+    geo_cols = [k["name"] for k in mapper["geo"] if "primary_geo" in k and k["primary_geo"] == True]
 
     # subset dataframe for only columns in mapper
     mapper_keys = []
@@ -647,8 +646,8 @@ def process(fp: str, mp: str, admin: str, output_file: str):
     del(norm_str['type'])
     del(norm['type'])    
 
-    #print('\n', norm.head())
-    #print('\n', norm_str.tail(100))
+    print('\n', norm.head())
+    print('\n', norm_str.tail(100))
 
     norm.to_parquet(f"{output_file}.parquet.gzip", compression="gzip")
     if len(norm_str) > 0:
@@ -656,8 +655,8 @@ def process(fp: str, mp: str, admin: str, output_file: str):
     return norm.append(norm_str)
 
 # Testing
-#mp = 'examples/causemosify-tests/acled_schema2.json'
-#fp = 'examples/causemosify-tests/acled.csv'
-#geo = 'admin3'
-#outf = 'examples/causemosify-tests/acled_schema2'
-#process(fp, mp, geo, outf) 
+mp = 'examples/causemosify-tests/test_file_5_schema2.json'
+fp = 'examples/causemosify-tests/test_file_5_schema2.csv'
+geo = 'admin3'
+outf = 'examples/causemosify-tests/test_file_5_schema2'
+process(fp, mp, geo, outf) 

--- a/mixmasta/mixmasta.py
+++ b/mixmasta/mixmasta.py
@@ -683,8 +683,8 @@ def process(fp: str, mp: str, admin: str, output_file: str):
     del(norm_str['type'])
     del(norm['type'])    
 
-    print('\n', norm.head())
-    print('\n', norm_str.tail())
+    #print('\n', norm.head())
+    #print('\n', norm_str.tail())
 
     norm.to_parquet(f"{output_file}.parquet.gzip", compression="gzip")
     if len(norm_str) > 0:
@@ -692,8 +692,8 @@ def process(fp: str, mp: str, admin: str, output_file: str):
     return norm.append(norm_str)
 
 # Testing
-mp = 'examples/causemosify-tests/test_file_5_schema2.json'
-fp = 'examples/causemosify-tests/test_file_5_schema2.csv'
-geo = 'admin3'
-outf = 'examples/causemosify-tests/test_file_5_schema2'
-process(fp, mp, geo, outf) 
+#mp = 'examples/causemosify-tests/test_file_5_schema2.json'
+#fp = 'examples/causemosify-tests/test_file_5_schema2.csv'
+#geo = 'admin3'
+#outf = 'examples/causemosify-tests/test_file_5_schema2'
+#process(fp, mp, geo, outf) 

--- a/mixmasta/mixmasta.py
+++ b/mixmasta/mixmasta.py
@@ -277,11 +277,13 @@ def normalizer(df: pd.DataFrame, mapper: dict, admin: str) -> pd.DataFrame:
     # and perform type conversion on the time column
     features = []
     for kk, vv in mapper.items():
-
+               
         if kk in time_cols:
-            df[kk] = df[kk].apply(
-                lambda x: format_time(str(x), vv["Time_format"], validate=False)
-            )
+            # convert primary_time to epochtime if not already.
+            if vv["Time"] == "Date":
+                df[kk] = df[kk].apply(
+                    lambda x: format_time(str(x), vv["Time_format"], validate=False)
+                )
             staple_col_name = "timestamp"
             df.rename(columns={kk: staple_col_name}, inplace=True)
         elif kk in geo_cols:
@@ -321,8 +323,8 @@ def normalizer(df: pd.DataFrame, mapper: dict, admin: str) -> pd.DataFrame:
                     df["admin3"] = df[kk]                
                     continue
             
-            # Convert all date/time to epoch time.
-            if kk in other_time_cols:
+            # Convert all date/time to epoch time if not already.
+            if kk in other_time_cols and vv["Time"] == "Date":
                 df[kk] = df[kk].apply(
                     lambda x: format_time(str(x), vv["Time_format"], validate=False)
                 )

--- a/requirements.txt
+++ b/requirements.txt
@@ -20,3 +20,4 @@ rasterio>=1.1.0
 xarray==0.16.1
 tqdm>=4.41.1,<5.0.0
 geofeather>=0.3.0
+fuzzywuzzy>=0.18.0 

--- a/requirements.txt
+++ b/requirements.txt
@@ -19,4 +19,4 @@ netCDF4==1.5.3
 rasterio>=1.1.0
 xarray==0.16.1
 tqdm>=4.41.1,<5.0.0
-geofeather==0.3.0
+geofeather>=0.3.0


### PR DESCRIPTION
Address Issue #9 Convert all date/time to epoch time and #16 Support various time types

If there is no `primary_time` column for `timestamp`, attempt to generate from `Time`= Month, Day or Year features.

Int values are written to the standard parquet file and will be read as FLOAT if other float/double values are present.

Djibouti Food prices data files to test (remove .txt extension):

[WFP_2021Mar31_Djibouti_FoodPricesData.csv.txt](https://github.com/jataware/mixmasta/files/6562369/WFP_2021Mar31_Djibouti_FoodPricesData.csv.txt)
[WFP_2021Mar31_Djibouti_FoodPricesData.json.txt](https://github.com/jataware/mixmasta/files/6562370/WFP_2021Mar31_Djibouti_FoodPricesData.json.txt)

