### PR TITLE
Features/rtk qualifier

### DIFF
--- a/docs/geo-entity-resolution.md
+++ b/docs/geo-entity-resolution.md
@@ -1,0 +1,25 @@
+
+## mixmasta Geo Entity Resolution
+
+## Example Cases
+- [Latitude / Longitude](#latitude-/-longitude)
+- [Coordinates](#coordinates)
+- [Place Names](#place-names)
+
+### Latitude / Longitude
+If *latitude* and *longitude* are specified, *primary_geo* = *TRUE*, and *is_geo_pair* 
+refers to the paired value, then the lat/lon values are geocoded to [GADM](https://gadm.org/)
+place names of country, admin1 (state/territory), admin2 (county/district), and if specified, 
+admin3 (municipality/town).
+
+### Coordinates
+If *coordinate* data is specified, then these values are translated to latitude and 
+longitude based on *coord_format*, and then geocoded to [GADM](https://gadm.org/) as above
+for [Latitude / Longitude](#latitude-/-longitude).
+
+### Place Names
+If none of the above cases is satisifed, then specified geo fields 
+will be mapped to *country*, *admin1*, etc. Place names in these fields will be mapped 
+to [GADM](https://gadm.org/) place names *dependent on the assumption that the **country** is provided* and matches 
+the [GADM](https://gadm.org/) country name. Unmatched place names for admin1, admin2, and admin3, e.g. due to typos, misspellings, are mapped
+to the best [GADM](https://gadm.org/) match using [Levenshtein distance](https://en.wikipedia.org/wiki/Levenshtein_distance) fuzzy string matching.

--- a/mixmasta/mixmasta.py
+++ b/mixmasta/mixmasta.py
@@ -585,9 +585,13 @@ def normalizer(df: pd.DataFrame, mapper: dict, admin: str) -> pd.DataFrame:
                 df["lng"] = longs
                 df["lat"] = lats
                 del df[kk]
+            elif geo_dict["geo_type"] == "country" and kk != "country":
+                # force the country column to be named country
+                staple_col_name = "country"
+                df.rename(columns={kk: staple_col_name}, inplace=True)                
         elif "qualifies" in geo_dict and geo_dict["qualifies"]:
-            # Note that any “qualifier” column that is not primary geo/date 
-            # will just be lopped on to the right as its own column. It’s 
+            # Note that any "qualifier" column that is not primary geo/date 
+            # will just be lopped on to the right as its own column. It'’'s 
             # column name will just be the name and Uncharted will deal with 
             # it. The key takeaway is that qualifier columns grow the width, 
             # not the length of the dataset.
@@ -626,8 +630,8 @@ def normalizer(df: pd.DataFrame, mapper: dict, admin: str) -> pd.DataFrame:
         if "qualifies" not in feature_dict or not feature_dict["qualifies"]:
             features.append(feature_dict["name"])
         elif "qualifies" in feature_dict and feature_dict["qualifies"]: 
-            # Note that any “qualifier” column that is not primary geo/date 
-            # will just be lopped on to the right as its own column. It’s 
+            # Note that any "qualifier" column that is not primary geo/date 
+            # will just be lopped on to the right as its own column. It's 
             # column name will just be the name and Uncharted will deal with 
             # it. The key takeaway is that qualifier columns grow the width, 
             # not the length of the dataset.
@@ -647,7 +651,6 @@ def normalizer(df: pd.DataFrame, mapper: dict, admin: str) -> pd.DataFrame:
         df = geocode(admin, df, x="lng", y="lat")
     elif len(primary_geo_cols) == 0 and "country" in df:
         # Correct any misspellings etc. in state and admin areas only when
-        # 
         df = match_geo_names(admin, df)
 
     df_geo_cols = [i for i in df.columns if 'mixmasta_geocoded' in i]
@@ -775,9 +778,9 @@ def process(fp: str, mp: str, admin: str, output_file: str):
 
 # Testing
 """
-mp = 'examples/causemosify-tests/test_file_5_schema2.json'
-fp = 'examples/causemosify-tests/test_file_5_schema2.csv'
+mp = 'examples/causemosify-tests/to_validate.json'
+fp = 'examples/causemosify-tests/raw_data.csv'
 geo = 'admin3'
-outf = 'examples/causemosify-tests/test_file_5_schema2'
+outf = 'examples/causemosify-tests/spacetag_test'
 process(fp, mp, geo, outf) 
 """

--- a/mixmasta/mixmasta.py
+++ b/mixmasta/mixmasta.py
@@ -525,7 +525,7 @@ def normalizer(df: pd.DataFrame, mapper: dict, admin: str) -> pd.DataFrame:
         if not "timestamp" in df.columns:
             new_column_name = "timestamp"
         else:
-            new_column_name = ''.join(assoc_fields)
+            new_column_name = ''.join(sorted(assoc_fields))
 
         df = df.join(df.apply(generate_timestamp, date_mapper=assoc_columns, column_name=new_column_name, axis=1))
         df[new_column_name] = df[new_column_name].apply(lambda x: format_time(str(x), "%m/%d/%y", validate=False))


### PR DESCRIPTION
@brandomr There are a couple unhandled confounds / edge cases :

- if a column qualifies a `geo` `state` column (for example), and that column is renamed `admin1`, the `admin1` column is not qualified.
- if column qualifies a `geo` `date` `day`, `month`, or `year` column, and those are used to create a epoch time, that new epoch time is not qualified.

Should these be handled?