### PR TITLE
Feature/rtk verifyschema

### DIFF
--- a/mixmasta/mixmasta.py
+++ b/mixmasta/mixmasta.py
@@ -21,7 +21,9 @@ import fuzzywuzzy
 from fuzzywuzzy import fuzz
 from fuzzywuzzy import process
 import timeit
-#
+from spacetag_schema import SpaceModel
+
+
 if not sys.warnoptions:
     import warnings
 
@@ -470,9 +472,10 @@ def normalizer(df: pd.DataFrame, mapper: dict, admin: str) -> pd.DataFrame:
     qualified_col_dict = {}
 
     # subset dataframe for only columns specified in mapper schema.
+    # get all named objects in the date, feature, geo schema lists.
     mapper_keys = []
     for k in mapper.items():
-        mapper_keys.extend([l['name'] for l in k[1]])
+        mapper_keys.extend([l['name'] for l in k[1] if 'name' in l])
     df = df[mapper_keys]
 
     # Rename protected columns
@@ -734,7 +737,14 @@ def process(fp: str, mp: str, admin: str, output_file: str):
         Example: https://github.com/jataware/spacetag/blob/schema/example.json
 
     """
+
+    # Read JSON schema to be mapper.
     mapper = json.loads(open(mp).read())
+
+    # Validate JSON mapper schema against SpaceTag schema.py model.
+    model = SpaceModel(geo=mapper['geo'], date=mapper['date'], feature=mapper['feature'], meta=mapper['meta'])
+
+    # "meta" portion of schema specifies transformation type
     transform = mapper["meta"]
 
     # Make mapper contain only keys for date, geo, and feature.
@@ -778,9 +788,9 @@ def process(fp: str, mp: str, admin: str, output_file: str):
 
 # Testing
 """
-mp = 'examples/causemosify-tests/to_validate.json'
-fp = 'examples/causemosify-tests/raw_data.csv'
+mp = 'examples/causemosify-tests/test_file_5_schema2.json'
+fp = 'examples/causemosify-tests/test_file_5_schema2.csv'
 geo = 'admin3'
-outf = 'examples/causemosify-tests/spacetag_test'
+outf = 'examples/causemosify-tests/test_file_5_schema2'
 process(fp, mp, geo, outf) 
 """

--- a/mixmasta/mixmasta.py
+++ b/mixmasta/mixmasta.py
@@ -742,7 +742,7 @@ def process(fp: str, mp: str, admin: str, output_file: str):
     mapper = json.loads(open(mp).read())
 
     # Validate JSON mapper schema against SpaceTag schema.py model.
-    #model = SpaceModel(geo=mapper['geo'], date=mapper['date'], feature=mapper['feature'], meta=mapper['meta'])
+    model = SpaceModel(geo=mapper['geo'], date=mapper['date'], feature=mapper['feature'], meta=mapper['meta'])
 
     # "meta" portion of schema specifies transformation type
     transform = mapper["meta"]
@@ -789,9 +789,9 @@ def process(fp: str, mp: str, admin: str, output_file: str):
 
 # Testing
 """
-mp = 'examples/causemosify-tests/test_file_2_schema2.json'
-fp = 'examples/causemosify-tests/test_file_2_schema2.csv'
+mp = 'examples/causemosify-tests/test_file_5_schema2.json'
+fp = 'examples/causemosify-tests/test_file_5_schema2.csv'
 geo = 'admin3'
-outf = 'examples/causemosify-tests/test_file_2_schema2'
+outf = 'examples/causemosify-tests/test_file_5_schema2'
 process(fp, mp, geo, outf) 
 """

--- a/mixmasta/spacetag_schema.py
+++ b/mixmasta/spacetag_schema.py
@@ -79,7 +79,6 @@ class GeoAnnotation(BaseModel):
         example=["crop_production", "malnutrition_rate"],
     )
 
-
 class TimeField(str, Enum):
     YEAR = "year"
     MONTH = "month"
@@ -99,8 +98,10 @@ class DateAnnotation(BaseModel):
         example="%y",
     )
     date_type: DateType
-    #Following line throws Exception "TypeError: 'type' object is not subscriptable"
-    #associated_columns: Optional[dict[TimeField, str]] = Field(
+    # The following line 
+    # associated_columns: Optional[dict[TimeField, str]] = Field(
+    # throws Exception "TypeError: 'type' object is not subscriptable"
+    # Solve by not subscripting the dicionary; instead, add a validator. 
     associated_columns: Optional[dict] = Field(
         title="Associated datetime column",
         description="the type of time as the key with the column name being the value",
@@ -115,10 +116,19 @@ class DateAnnotation(BaseModel):
     @validator('date_type')
     def time_format_optional(cls, v, values):
         if v == DateType.DATE and values["time_format"] == None:
-                raise ValueError('time_format is required for when date_type is date')
+            raise ValueError('time_format is required for when date_type is date')
         return v
 
-
+    @validator('associated_columns')
+    def validate_associated_columns(cls, v):
+        # v is type dict
+        # validate it is dict[TimeField, str]
+        timefield_list = [e.value for e in TimeField]
+        for kk, vv in v.items():
+            if kk not in timefield_list:
+                raise ValueError(str.format('Date associated_columns dictionary key must be of type TimeField: {} in {}', kk, v))
+            elif type(vv) is not str:
+                raise ValueError(str.format('Date associated_columns dictionary value must be of type string: {} in {}', vv, v))
 
 class FeatureAnnotation(BaseModel):
     name: str

--- a/mixmasta/spacetag_schema.py
+++ b/mixmasta/spacetag_schema.py
@@ -1,0 +1,155 @@
+from typing import Optional, List, Union
+from enum import Enum
+from pydantic import BaseModel, Field, validator
+from typing_extensions import TypedDict
+
+
+
+#############################
+#### DEFINE ENUMERATIONS ####
+#############################
+class FileType(str, Enum):
+    CSV = "csv"
+    EXCEL = "excel"
+    NETCDF = "netcdf"
+    GEOTIFF = "geotiff"
+
+
+class ColumnType(str, Enum):
+    DATE = "date"
+    GEO = "geo"
+    FEATURE = "feature"
+
+
+class DateType(str, Enum):
+    YEAR = "year"
+    MONTH = "month"
+    DAY = "day"
+    EPOCH = "epoch"
+    DATE = "date"
+
+
+class GeoType(str, Enum):
+    LATITUDE = "latitude"
+    LONGITUDE = "longitude"
+    COORDINATES = "coordinates"
+    COUNTRY = "country"
+    ISO2 = "iso2"
+    ISO3 = "iso3"
+    STATE = "state/territory"
+    COUNTY = "county/district"
+    CITY = "municipality/town"
+
+
+class FeatureType(str, Enum):
+    INT = "int"
+    FLOAT = "float"
+    STR = "str"
+    BINARY = "binary"
+    BOOLEAN = "boolean"
+
+
+class CoordFormat(str, Enum):
+    LONLAT = "lonlat"
+    LATLON = "latlon"
+
+
+#################################
+#### DEFINE ANNOTATION TYPES ####
+#################################
+class GeoAnnotation(BaseModel):
+    name: str
+    display_name: Optional[str]
+    description: Optional[str]
+    type: ColumnType = "geo"
+    geo_type: GeoType
+    primary_geo: Optional[bool]
+    is_geo_pair: Optional[str] = Field(
+        title="Geo Pair",
+        description="If present, this is the name of a paired coordinate column.",
+        example="Lon_",
+    )
+    coord_format: Optional[CoordFormat] = Field(
+        title="Coordinate Format",
+        description="If geo type is COORDINATES, then provide the coordinate format",
+    )
+    qualifies: Optional[List[str]] = Field(
+        title="Qualifies Columns",
+        description="An array of the column names which this qualifies",
+        example=["crop_production", "malnutrition_rate"],
+    )
+
+
+class TimeField(str, Enum):
+    YEAR = "year"
+    MONTH = "month"
+    DAY = "day"
+    HOUR = "hour"
+    MINUTE = "minute"
+
+class DateAnnotation(BaseModel):
+    name: str = Field(example="year_column")
+    display_name: Optional[str]
+    description: Optional[str]
+    type: ColumnType = "date"
+    primary_date: Optional[bool]
+    time_format: Optional[str] = Field(
+        title="Time Format",
+        description="The strftime formatter for this field",
+        example="%y",
+    )
+    date_type: DateType
+    #Following line throws Exception "TypeError: 'type' object is not subscriptable"
+    #associated_columns: Optional[dict[TimeField, str]] = Field(
+    associated_columns: Optional[dict] = Field(
+        title="Associated datetime column",
+        description="the type of time as the key with the column name being the value",
+        example={"day": "day_column", "hour": "hour_column"},
+    )
+    qualifies: Optional[List[str]] = Field(
+        title="Qualifies Columns",
+        description="An array of the column names which this qualifies",
+        example=["crop_production", "malnutrition_rate"],
+    )
+
+    @validator('date_type')
+    def time_format_optional(cls, v, values):
+        if v == DateType.DATE and values["time_format"] == None:
+                raise ValueError('time_format is required for when date_type is date')
+        return v
+
+
+
+class FeatureAnnotation(BaseModel):
+    name: str
+    display_name: Optional[str]
+    description: Optional[str]
+    type: ColumnType = "feature"
+    feature_type: FeatureType
+    units: Optional[str]
+    units_description: Optional[str]
+    qualifies: Optional[List[str]] = Field(
+        title="Qualifies Columns",
+        description="An array of the column names which this qualifies",
+        example=["crop_production", "malnutrition_rate"],
+    )
+
+
+#########################
+#### DEFINE METADATA ####
+#########################
+class Meta(BaseModel):
+    ftype: FileType
+    band: Optional[str]
+    sheet: Optional[str]
+    date: Optional[str]
+
+
+############################
+#### DEFINE FINAL MODEL ####
+############################
+class SpaceModel(BaseModel):
+    geo: List[Optional[GeoAnnotation]]
+    date: List[Optional[DateAnnotation]]
+    feature: List[FeatureAnnotation]
+    meta: Meta


### PR DESCRIPTION
- Fixes `year`, `month`, `day` conversion to epoch time when `primary_date` = `true`.
- Added copy of [SpaceTag schema](https://github.com/jataware/spacetag/blob/schema/schema.py) and added validators:
--  `date_type` validator makes `time_format` a required field only when `date_type` is `date`
-- `associated_columns` validator confirms the `dict` format is `TimeField: str`. This was necessary because the declaration `associated_columns: Optional[dict[TimeField, str]]` was throwing an `Exception` `"TypeError: 'type' object is not subscriptable"`; so removed the dict parameters (ie. `associated_columns: Optional[dict]`).
