### PR TITLE
Feature/rtk date qualifies

### DIFF
--- a/mixmasta/data/iso_lookup.csv
+++ b/mixmasta/data/iso_lookup.csv
@@ -1,0 +1,256 @@
+country,iso2,iso3
+Åland,AX,ALA
+Afghanistan,AF,AFG
+Akrotiri and Dhekelia,XAD,XAD
+Albania,AL,ALB
+Algeria,DZ,DZA
+American Samoa,AS,ASM
+Andorra,AD,AND
+Angola,AO,AGO
+Anguilla,AI,AIA
+Antarctica,AQ,ATA
+Antigua and Barbuda,AG,ATG
+Argentina,AR,ARG
+Armenia,AM,ARM
+Aruba,AW,ABW
+Australia,AU,AUS
+Austria,AT,AUT
+Azerbaijan,AZ,AZE
+Bahamas,BS,BHS
+Bahrain,BH,BHR
+Bangladesh,BD,BGD
+Barbados,BB,BRB
+Belarus,BY,BLR
+Belgium,BE,BEL
+Belize,BZ,BLZ
+Benin,BJ,BEN
+Bermuda,BM,BMU
+Bhutan,BT,BTN
+Bolivia,BO,BOL
+"Bonaire, Sint Eustatius and Saba",BQ,BES
+Bosnia and Herzegovina,BA,BIH
+Botswana,BW,BWA
+Bouvet Island,BV,BVT
+Brazil,BR,BRA
+British Indian Ocean Territory,IO,IOT
+British Virgin Islands,VG,VGB
+Brunei,BN,BRN
+Bulgaria,BG,BGR
+Burkina Faso,BF,BFA
+Burundi,BI,BDI
+Côte d'Ivoire,CI,CIV
+Cambodia,KH,KHM
+Cameroon,CM,CMR
+Canada,CA,CAN
+Cape Verde,CV,CPV
+Caspian Sea,XCA,XCA
+Cayman Islands,KY,CYM
+Central African Republic,CF,CAF
+Chad,TD,TCD
+Chile,CL,CHL
+China,CN,CHN
+Christmas Island,CX,CXR
+Cocos Islands,CC,CCK
+Colombia,CO,COL
+Comoros,KM,COM
+Cook Islands,CK,COK
+Costa Rica,CR,CRI
+Croatia,HR,HRV
+Cuba,CU,CUB
+Curaçao,CW,CUW
+Cyprus,CY,CYP
+Czech Republic,CZ,CZE
+Democratic Republic of the Congo,CD,COD
+Denmark,DK,DNK
+Djibouti,DJ,DJI
+Dominica,DM,DMA
+Dominican Republic,DO,DOM
+Ecuador,EC,ECU
+Egypt,EG,EGY
+El Salvador,SV,SLV
+Equatorial Guinea,GQ,GNQ
+Eritrea,ER,ERI
+Estonia,EE,EST
+Ethiopia,ET,ETH
+Falkland Islands,FK,FLK
+Faroe Islands,FO,FRO
+Fiji,FJ,FJI
+Finland,FI,FIN
+France,FR,FRA
+French Guiana,GF,GUF
+French Polynesia,PF,PYF
+French Southern Territories,TF,ATF
+Gabon,GA,GAB
+Gambia,GM,GMB
+Georgia,GE,GEO
+Germany,DE,DEU
+Ghana,GH,GHA
+Gibraltar,GI,GIB
+Greece,GR,GRC
+Greenland,GL,GRL
+Grenada,GD,GRD
+Guadeloupe,GP,GLP
+Guam,GU,GUM
+Guatemala,GT,GTM
+Guernsey,GG,GGY
+Guinea,GN,GIN
+Guinea-Bissau,GW,GNB
+Guyana,GY,GUY
+Haiti,HT,HTI
+Heard Island and McDonald Islands,HM,HMD
+Honduras,HN,HND
+Hong Kong,HK,HKG
+Hungary,HU,HUN
+Iceland,IS,ISL
+India,IN,IND
+Indonesia,ID,IDN
+Iran,IR,IRN
+Iraq,IQ,IRQ
+Ireland,IE,IRL
+Isle of Man,IM,IMN
+Israel,IL,ISR
+Italy,IT,ITA
+Jamaica,JM,JAM
+Japan,JP,JPN
+Jersey,JE,JEY
+Jordan,JO,JOR
+Kazakhstan,KZ,KAZ
+Kenya,KE,KEN
+Kiribati,KI,KIR
+Kosovo,XK,XKO
+Kuwait,KW,KWT
+Kyrgyzstan,KG,KGZ
+Laos,LA,LAO
+Latvia,LV,LVA
+Lebanon,LB,LBN
+Lesotho,LS,LSO
+Liberia,LR,LBR
+Libya,LY,LBY
+Liechtenstein,LI,LIE
+Lithuania,LT,LTU
+Luxembourg,LU,LUX
+Macao,MO,MAC
+Macedonia,MK,MKD
+Madagascar,MG,MDG
+Malawi,MW,MWI
+Malaysia,MY,MYS
+Maldives,MV,MDV
+Mali,ML,MLI
+Malta,MT,MLT
+Marshall Islands,MH,MHL
+Martinique,MQ,MTQ
+Mauritania,MR,MRT
+Mauritius,MU,MUS
+Mayotte,YT,MYT
+Mexico,MX,MEX
+Micronesia,FM,FSM
+Moldova,MD,MDA
+Monaco,MC,MCO
+Mongolia,MN,MNG
+Montenegro,ME,MNE
+Montserrat,MS,MSR
+Morocco,MA,MAR
+Mozambique,MZ,MOZ
+Myanmar,MM,MMR
+Namibia,,NAM
+Nauru,NR,NRU
+Nepal,NP,NPL
+Netherlands,NL,NLD
+New Caledonia,NC,NCL
+New Zealand,NZ,NZL
+Nicaragua,NI,NIC
+Niger,NE,NER
+Nigeria,NG,NGA
+Niue,NU,NIU
+Norfolk Island,NF,NFK
+North Korea,KP,PRK
+Northern Cyprus,XNC,XNC
+Northern Mariana Islands,MP,MNP
+Norway,NO,NOR
+Oman,OM,OMN
+Pakistan,PK,PAK
+Palau,PW,PLW
+Palestina,PS,PSE
+Panama,PA,PAN
+Papua New Guinea,PG,PNG
+Paracel Islands,XPI,XPI
+Paraguay,PY,PRY
+Peru,PE,PER
+Philippines,PH,PHL
+Pitcairn Islands,PN,PCN
+Poland,PL,POL
+Portugal,PT,PRT
+Puerto Rico,PR,PRI
+Qatar,QA,QAT
+Republic of Congo,CG,COG
+Reunion,RE,REU
+Romania,RO,ROU
+Russia,RU,RUS
+Rwanda,RW,RWA
+Sao Tome and Principe,ST,STP
+Saint Helena,SH,SHN
+Saint Kitts and Nevis,KN,KNA
+Saint Lucia,LC,LCA
+Saint Pierre and Miquelon,PM,SPM
+Saint Vincent and the Grenadines,VC,VCT
+Saint-Barthélemy,BL,BLM
+Saint-Martin,MF,MAF
+Samoa,WS,WSM
+San Marino,SM,SMR
+Saudi Arabia,SA,SAU
+Senegal,SN,SEN
+Serbia,RS,SRB
+Seychelles,SC,SYC
+Sierra Leone,SL,SLE
+Singapore,SG,SGP
+Sint Maarten,SX,SXM
+Slovakia,SK,SVK
+Slovenia,SI,SVN
+Solomon Islands,SB,SLB
+Somalia,SO,SOM
+South Africa,ZA,ZAF
+South Georgia and the South Sandwich Islands,GS,SGS
+South Korea,KR,KOR
+South Sudan,SS,SSD
+Spain,ES,ESP
+Spratly Islands,XSP,XSP
+Sri Lanka,LK,LKA
+Sudan,SD,SDN
+Suriname,SR,SUR
+Svalbard and Jan Mayen,SJ,SJM
+Swaziland,SZ,SWZ
+Sweden,SE,SWE
+Switzerland,CH,CHE
+Syria,SY,SYR
+Taiwan,TW,TWN
+Tajikistan,TJ,TJK
+Tanzania,TZ,TZA
+Thailand,TH,THA
+Timor-Leste,TL,TLS
+Togo,TG,TGO
+Tokelau,TK,TKL
+Tonga,TO,TON
+Trinidad and Tobago,TT,TTO
+Tunisia,TN,TUN
+Turkey,TR,TUR
+Turkmenistan,TM,TKM
+Turks and Caicos Islands,TC,TCA
+Tuvalu,TV,TUV
+Uganda,UG,UGA
+Ukraine,UA,UKR
+United Arab Emirates,AE,ARE
+United Kingdom,GB,GBR
+United States,US,USA
+United States Minor Outlying Islands,UM,UMI
+Uruguay,UY,URY
+Uzbekistan,UZ,UZB
+Vanuatu,VU,VUT
+Vatican City,VA,VAT
+Venezuela,VE,VEN
+Vietnam,VN,VNM
+"Virgin Islands, U.S.",VI,VIR
+Wallis and Futuna,WF,WLF
+Western Sahara,EH,ESH
+Yemen,YE,YEM
+Zambia,ZM,ZMB
+Zimbabwe,ZW,ZWE

--- a/mixmasta/mixmasta.py
+++ b/mixmasta/mixmasta.py
@@ -386,12 +386,12 @@ def match_geo_names(admin: str, df: pd.DataFrame) -> pd.DataFrame:
     countries = df["country"].unique()
 
     # Correct country names.
-    #gadm_country_list = gadm["country"].unique()
-    #unknowns = ~df.country.isin(gadm_country_list).country.tolist()
-    #for unk in unknowns:
-    #    match = fuzzywuzzy.process.extractOne(unk, gadm_country_list, scorer=fuzz.ratio)
-    #    if match != None:
-    #        df.loc[df.country == unk, 'country'] = match[0]
+    gadm_country_list = gadm["country"].unique()
+    unknowns = df[~df.country.isin(gadm_country_list)].country.tolist()
+    for unk in unknowns:
+        match = fuzzywuzzy.process.extractOne(unk, gadm_country_list, scorer=fuzz.ratio)
+        if match != None:
+            df.loc[df.country == unk, 'country'] = match[0]
 
     # Filter GADM dicitonary for only those countries (ie. speed up)
     gadm = gadm[gadm["country"].isin(countries)]
@@ -911,7 +911,7 @@ def process(fp: str, mp: str, admin: str, output_file: str):
         norm_str.to_parquet(f"{output_file}_str.parquet.gzip", compression="gzip")
 
     # Testing
-    """
+
     #print('\n', norm.append(norm_str).head(50))
     #print('\n', norm.append(norm_str).tail(50))
 
@@ -919,7 +919,7 @@ def process(fp: str, mp: str, admin: str, output_file: str):
     print('\n', norm.tail(50))
     print('\n', norm_str.head(50))
     print('\n', renamed_col_dict)
-    """
+
 
 
     return norm.append(norm_str), renamed_col_dict
@@ -1008,14 +1008,14 @@ def raster2df(
     return df
 
 # Testing
-"""
+
 mp = 'examples/causemosify-tests/mixmasta_ready_annotations_timestampfeature.json'
 fp = 'examples/causemosify-tests/raw_excel_timestampfeature.xlsx'
 geo = 'admin3'
 outf = 'examples/causemosify-tests/testing'
 
 process(fp, mp, geo, outf)
-
+"""
 mapper = json.loads(open(mp).read())
 mapper = { k: mapper[k] for k in mapper.keys() & {"date", "geo", "feature"} }
 df = pd.read_csv(fp)

--- a/mixmasta/mixmasta.py
+++ b/mixmasta/mixmasta.py
@@ -16,10 +16,12 @@ from osgeo import gdal, gdalconst
 from shapely import speedups
 from shapely.geometry import Point
 
+from pathlib import Path
+
 import fuzzywuzzy
 from fuzzywuzzy import fuzz
 from fuzzywuzzy import process
-import timeit
+#import timeit
 #from .spacetag_schema import SpaceModel
 
 if not sys.warnoptions:
@@ -183,7 +185,7 @@ def generate_column_name(field_list: list) -> str:
 
     Returns
     -------
-    str new column name
+    str: new column name
 
     """
     return ''.join(sorted(field_list))
@@ -263,6 +265,46 @@ def generate_timestamp_format(date_mapper: dict) -> str:
             year = vv["time_format"]
 
     return str.format("{}/{}/{}", month, day, year)
+
+def get_iso_country_dict(iso_list: list) -> dict:
+    """
+    Description
+    -----------
+    iso2 or iso3 is used as primary_geo and therefore the country column.
+    Load the custom iso lookup table and return a dictionary of the iso codes
+    as keys and the country names as values. Assume all list items are the same
+    iso type.
+
+    Parameters
+    ----------
+    iso_list:
+        list of iso2 or iso3 codes
+
+    Returns
+    -------
+    dict:
+        key: iso code; value: country name
+
+    """
+    dct = {}
+    if iso_list:
+        path = Path(__file__).parent / "data/iso_lookup.csv"
+        iso_df = pd.read_csv(path)
+
+        if iso_df.empty:
+            return dct
+
+        if len(iso_list[0]) == 2:
+            for iso in iso_list:
+                if iso in iso_df["iso2"].values:
+                    dct[iso] = iso_df.loc[iso_df["iso2"] == iso]["country"].item()
+        else:
+            for iso in iso_list:
+                if iso in iso_df["iso3"].values:
+                    dct[iso] = iso_df.loc[iso_df["iso3"] == iso]["country"].item()
+
+
+    return dct
 
 def handle_colname_collisions(df: pd.DataFrame, mapper: dict, protected_cols: list) -> (pd.DataFrame, dict, dict):
     """
@@ -695,10 +737,16 @@ def normalizer(df: pd.DataFrame, mapper: dict, admin: str) -> (pd.DataFrame, dic
                 #renamed_col_dict[staple_col_name] = [kk] # 7/2/2021 do not include primary cols
             elif str(geo_dict["geo_type"]).lower() in ["iso2", "iso3"]:
                 # use the ISO2 or ISO3 column as country
+
+                # use ISO2/3 lookup dictionary to change ISO to country name.
+                iso_list = df[kk].unique().tolist()
+                dct = get_iso_country_dict(iso_list)
+                df[kk] = df[kk].apply(lambda x: dct[x] if x in dct else x)
+
+                # now rename that column as "country"
                 staple_col_name = "country"
                 df.rename(columns={kk: staple_col_name}, inplace=True)
                 #renamed_col_dict[staple_col_name] = [kk] # 7/2/2021 do not include primary cols
-                # TODO: use ISO2/3 lookup dictionary to change ISO to country name.
 
         elif "qualifies" in geo_dict and geo_dict["qualifies"]:
             # Note that any "qualifier" column that is not primary geo/date
@@ -764,9 +812,13 @@ def normalizer(df: pd.DataFrame, mapper: dict, admin: str) -> (pd.DataFrame, dic
     # perform geocoding if lat/lng are present
     if "lat" in df and "lng" in df:
         df = geocode(admin, df, x="lng", y="lat")
-    elif "country" in df:
+    #elif "country" in df:
+    elif "country" in primary_geo_cols or ("country" in df and not primary_geo_cols):
         # Correct any misspellings etc. in state and admin areas when not
-        # geocoding lat and lng above.
+        # geocoding lat and lng above, and country is the primary_geo.
+        # This don't match names if iso2/iso3 are primary, and when country
+        # admin1-3 are moved to features. Exception is when country is present,
+        # but nothing is marked as primary.
         df = match_geo_names(admin, df)
 
     df_geo_cols = [i for i in df.columns if 'mixmasta_geocoded' in i]
@@ -914,13 +966,12 @@ def process(fp: str, mp: str, admin: str, output_file: str):
 
     #print('\n', norm.append(norm_str).head(50))
     #print('\n', norm.append(norm_str).tail(50))
-
+    """
     print('\n', norm.head(50))
     print('\n', norm.tail(50))
     print('\n', norm_str.head(50))
     print('\n', renamed_col_dict)
-
-
+    """
 
     return norm.append(norm_str), renamed_col_dict
 
@@ -1008,14 +1059,14 @@ def raster2df(
     return df
 
 # Testing
-
+"""
 mp = 'examples/causemosify-tests/mixmasta_ready_annotations_timestampfeature.json'
 fp = 'examples/causemosify-tests/raw_excel_timestampfeature.xlsx'
 geo = 'admin3'
 outf = 'examples/causemosify-tests/testing'
 
 process(fp, mp, geo, outf)
-"""
+
 mapper = json.loads(open(mp).read())
 mapper = { k: mapper[k] for k in mapper.keys() & {"date", "geo", "feature"} }
 df = pd.read_csv(fp)

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@ Click>=7.0,<8
 coverage==4.5.4
 Cython==0.29.23
 flake8==3.7.8
-fuzzywuzzy>=0.18.0 
+fuzzywuzzy>=0.18.0
 GDAL==3.1.4
 geofeather>=0.3.0
 geopandas==0.8.1
@@ -13,6 +13,7 @@ openpyxl==3.0.7
 pip==19.2.3
 pydantic>=1.8.2
 pyproj==2.6.1.post1
+python-Levenshtein==0.12.2
 rasterio>=1.1.0
 Rtree==0.8.3
 Shapely==1.7.1


### PR DESCRIPTION
- correct country name to GADM when not geocoding lat lng
- iso code lookup and conversion to the GADM country name, and move to `country` column,  when iso2 or iso3 is `primary_geo`
- uses a 5KB csv file added to mixmasta/data; only loads once if ISO values need to be converted.

These are GADM countries where ISO2 codes could not be found:
- Akrotiri and Dhekelia
- Caspian Sea
- Northern Cyprus
- Paracel Islands
- Spratly Islands
