### PR TITLE
Fuzzy input matching for causemosify function

### DIFF
--- a/docs/docker.md
+++ b/docs/docker.md
@@ -7,6 +7,7 @@
 - [Convert geotiff to csv](#convert-geotiff-to-csv)
 - [Convert geotiff to *Geocoded* csv](#convert-geotiff-to-geocoded-csv)
 - [Convert a csv file to *Geocoded* csv](#convert-a-csv-file-to-geocoded-csv)
+- [Causemosify a file](#causemosify-a-file)
 - [Available CLI Parameters](#available-cli-parameters)
 
 ### Set-Up
@@ -95,6 +96,8 @@ docker run -v $PWD:/tmp \
 ```
 
 ### Causemosify a file
+
+This is a special case where Mixmasta is used to make a CauseMos compliant file. It requires a mapper file which contains instructions for how to perform this transformation. Note that the `input_file` can contain the `*` wildcard character. This is designed to support models which may produce non-deterministic filenames for their outputs. For example, if a model produces an output that appends an epoch timestamp to the filename (e.g. `sample_output_1625711342.csv`) this is problematic and should be abstracted to `sample_output_*.csv` by the Dojo system. This is handled by the `causemosify` function in `cli.py`.
 
 ```
 docker run -v $PWD:/tmp \

--- a/examples/mapper.json
+++ b/examples/mapper.json
@@ -1,80 +1,51 @@
 {
-    "annotations": {
-        "longitude": {
-            "Description": null,
-            "Type": "GEO",
-            "Geo": "Longitude",
-            "Primary_geo": "true",
-            "Is_geo_pair": "true",
-            "Primary_time": null,
-            "Coordinate_format": null,
-            "Data_type": null,
-            "Units": null,
-            "Timeformat": null,
-            "Year": null,
-            "Other_geo": "latitude",
-            "Time": null,
-            "Unit_description": null,
-            "New_col_name": null
+    "geo": [
+        {
+            "name": "latitude",
+            "display_name": "latitude",
+            "description": "location",
+            "type": "geo",
+            "geo_type": "latitude",
+            "primary_geo": true,
+            "is_geo_pair": "longitude"
         },
-        "latitude": {
-            "Description": null,
-            "Type": "GEO",
-            "Geo": "Latitude",
-            "Primary_geo": "true",
-            "Is_geo_pair": "true",
-            "Other_geo": "longitude",
-            "Primary_time": null,
-            "Coordinate_format": null,
-            "Data_type": null,
-            "Units": null,
-            "Timeformat": null,
-            "Year": null,
-            "Time": null,
-            "Unit_description": null,
-            "New_col_name": null
-        },
-        "rainfall": {
-            "Description": "rainfall in mm",
-            "Type": "OTHER",
-            "Data_type": "FLOAT",
-            "Units": null,
-            "Unit_description": null,
-            "Primary_time": null,
-            "Primary_geo": null,
-            "Coordinate_format": null,
-            "Timeformat": null,
-            "Year": null,
-            "Is_geo_pair": null,
-            "Other_geo": null,
-            "Time": null,
-            "Geo": null,
-            "New_col_name": null
-        },
-        "date": {
-            "Description": null,
-            "Type": "DATE/TIME",
-            "Time": "Date",
-            "Primary_time": "true",
-            "Time_format": "%m/%d/%Y",
-            "Primary_geo": null,
-            "Coordinate_format": null,
-            "Data_type": null,
-            "Units": null,
-            "Timeformat": null,
-            "Year": null,
-            "Is_geo_pair": null,
-            "Other_geo": null,
-            "Geo": null,
-            "Unit_description": null,
-            "New_col_name": null
+        {
+            "name": "longitude",
+            "display_name": "Longitude",
+            "description": "location",
+            "type": "geo",
+            "geo_type": "longitude",
+            "primary_geo": true,
+            "is_geo_pair": "latitude"
         }
-    },
+    ],
+    "date": [
+        {
+            "name": "date",
+            "display_name": "Date",
+            "description": "date",
+            "type": "date",
+            "date_type": "date",
+            "time_format": "%m/%d/%Y",
+            "primary_date": true
+        }
+    ],
+    "feature": [
+        {
+            "name": "rainfall",
+            "display_name": "Rainfall",
+            "description": "rainfall in mm",
+            "type": "feature",
+            "feature_type": "float",
+            "units": "mm",
+            "units_description": ""
+        }
+    ],
     "meta": {
-        "Feature_name": "rainfall",
-        "Band": "1",
-        "Null_val": "-9999",
-        "Date": "01/01/2021",
-        "ftype": "Geotiff"
+        "ftype": "geotiff",
+        "feature_name": "rainfall",
+        "band": "1",
+        "null_val": "-9999",
+        "date": "01/01/2021"
     }
 }

--- a/mixmasta/cli.py
+++ b/mixmasta/cli.py
@@ -8,6 +8,8 @@ import pandas as pd
 from .download import download_and_clean
 from .mixmasta import geocode, netcdf2df, process, raster2df
 
+from glob import glob
+
 
 @click.group()
 def cli():
@@ -22,6 +24,20 @@ def cli():
 def causemosify(input_file, mapper, geo, output_file):
     """Processor for generating CauseMos compliant datasets."""
     click.echo("Causemosifying data...")
+
+    # Enable wild card in file path
+    if "*" in input_file:
+        try:
+            input_file = glob(input_file)[0]
+            click.echo(
+                f'Wildcard character "*" detected; input file resolved to {input_file}'
+            )
+        except:
+            click.echo(
+                f'Unable to use wildcard character "*" to identify file; assuming {input_file} is actual file path.'
+            )
+            input_file = input_file
+
     return process(input_file, mapper, geo, output_file)
 
 


### PR DESCRIPTION
## What's New

The `input_file` argument to the `causemosify` function in `cli.py` can now contain the `*` wildcard character. 

## Rationale

This is designed to support models which may produce non-deterministic filenames for their outputs. For example, if a model produces an output that appends an epoch timestamp to the filename (e.g. `sample_output_1625711342.csv`) this is problematic and should be abstracted to `sample_output_*.csv` by the Dojo system. This is handled by the `causemosify` function in `cli.py`.

## Testing the PR

First, checkout the `fuzzy-input-file` branch. Then build the Docker container with:

```
docker build -t mixmasta-fuzzy .
```

Then run `cd examples` and:

```
docker run -v $PWD:/tmp \
           mixmasta-fuzzy \
           causemosify \
           --input_file="/tmp/chirps-v2.0.2021.*.tif" \
           --mapper=/tmp/mapper.json \
           --geo=admin3 \
           --output_file=/tmp/fuzzy_output_test
```

If successful, this will produce a parquet file called `fuzzy_output_test.parquet.gzip`. 

> Note the wildcard `*` in the `input_file` argument. This must now be quoted so as to not break the shell.

## Misc

This also includes an updated `examples/mapper.json` file that is compliant with the latest and greatest spacetag/mixmasta schema.