### PR TITLE
cli causemosify-multi write dfs to tmp parquet files #54

### DIFF
--- a/docs/causemosify-multi.md
+++ b/docs/causemosify-multi.md
@@ -1,0 +1,43 @@
+
+## CLI: causemosify-multi
+
+### Arguments
+
+`causemosify-multi` takes 3 arguments:
+
+- `--inputs`: string of JSON array of causemosify parameters in quotations with delimited interior quotations
+- `--geo`: e.g. admin2, admin3. Used for all submitted files.
+- `--output-file`: filename for parquets, defaults to "mixmasta_output"
+
+
+### Returns
+
+*Nothing*
+
+### Output Files
+
+- `{output-file}.{i}.parquet.gzip`
+- `{output-file}_str.{i}.parquet.gzip`
+
+where `{i}` is the 1-based iterator of the files passed in `--inputs`. It returns one set of parquet files for each input file.
+
+### Inputs Example
+
+`--inputs` interior quotation marks should be delimited:
+
+```
+"[{\"input_file\": \"build-a-date-qualifier_*.csv\", \"mapper\": \"build-a-date-qualifier.json\"}, {\"input_file\": \"raw_excel_timestampfeature.xlsx\", \"mapper\": \"mixmasta_ready_annotations_timestampfeature.json\"}]" 
+```
+
+### Testing
+
+Build the image:
+```
+/mixmasta$ docker build -t mixmasta .
+```
+
+Run causemosify. Here we run the command from a directory that contains the file `Test1_2D-Q.nc` and the indicated mapper file in the `mappers` directory. Both the local directory and `mappers` directory are mounted as volumes.
+```
+$ docker run -v ${PWD}:/tmp -v ${PWD}/mappers:/mappers mixmasta:latest causemosify-multi --inputs="[{\"input_file\":\"/tmp/Test1_2D-Q.nc\", \
+	  \"mapper\":\"./mappers/mapper_e489d023-58c3-4544-8ae1-bb9cfa987e23.json\"}]
+```

--- a/mixmasta/cli.py
+++ b/mixmasta/cli.py
@@ -5,12 +5,18 @@ from datetime import datetime
 import click
 import pandas as pd
 
-from .download import download_and_clean
-from .mixmasta import geocode, netcdf2df, process, raster2df
+#from .download import download_and_clean
+#from .mixmasta import geocode, netcdf2df, process, raster2df
+
+from download import download_and_clean
+from mixmasta import geocode, netcdf2df, process, raster2df, normalizer, optimize_df_types
+from mixmasta import mixdata
 
 from glob import glob
+import numpy as np
 
 import json
+import timeit
 
 
 @click.group()
@@ -38,7 +44,7 @@ def glob_input_file(input_file: str) -> str:
 @click.option("--mapper", type=str, default=None)
 @click.option("--geo", type=str, default=None)
 @click.option("--output_file", type=str, default="mixmasta_output")
-def causemosify(input_file, mapper, geo, output_file):
+def causemosify(input_file, mapper, geo: str, output_file):
     """Processor for generating CauseMos compliant datasets."""
     click.echo("Causemosifying data...")
 
@@ -46,80 +52,190 @@ def causemosify(input_file, mapper, geo, output_file):
     return process(input_file, mapper, geo, output_file)
 
 
-@cli.command()
-@click.option("--inputs", type=str, default=None)
-@click.option("--geo", type=str, default=None)
-@click.option("--output-file", type=str, default="mixmasta_output")
+#@cli.command()
+#@click.option("--inputs", type=str, default=None)
+#@click.option("--geo", type=str, default=None)
+#@click.option("--output-file", type=str, default="mixmasta_output")
 def causemosify_multi(inputs, geo, output_file):
     """Process multiple input files to generate a single CauseMos compliant dataset."""
 
-    # --inputs is one long gnarly string with interior quotations escaped e.g.:
-    # "[{\"input_file\": \"build-a-date-qualifier_*.csv\",
-    #        \"mapper\": \"build-a-date-qualifier.json\"}]"
+    """
+        Usurps mixmasta.process() to control memory use.
+    
+        --inputs is one long gnarly string with interior quotations escaped e.g.:
+        "[{\"input_file\": \"build-a-date-qualifier_*.csv\",
+                \"mapper\": \"build-a-date-qualifier.json\"}]"  
+    
+    
+    """
 
     input_array = json.loads(inputs)   
+    click.echo(f"Causemosifying {len(input_array)} file(s) ...")
+    
+    # Cache GADM for normalize() loops.
+    md = mixdata()
+    if geo.lower() == 'admin2':
+        click.echo('Loading GADM2 ...')
+        md.load_gadm2()
+        gadm = md.gadm2
+    else:
+        click.echo('Loading GADM3 ...')
+        md.load_gadm3()
+        gadm = md.gadm3
+
+    # Setup variables.
     renamed_col_dict = {}
-    temp_df_paths = []
-    temp_df_str_paths = []
-    df = pd.DataFrame()
+    df_datatypes = {}
+    df_columns = []
+    chunk_size = 100000
+    data_temp_filename = 'causmosify_multi_tmp'
+    processed_temp_filename = 'processed_tmp'
+    first_norm_time = 0
+
+    # Delete any previous tmp files.
+    for fl in glob(f'{processed_temp_filename}*'):
+        os.remove(fl)
+    
+    for fl in glob(f'{data_temp_filename}*'):
+        os.remove(fl)
+  
+    # Iterate each item in the --inputs JSON.
     for item in input_array:
-        # Handle filename wildcards.
+        # Handle filename wildcards with glob_input_file().
         input_file =  glob_input_file(item["input_file"])
+        click.echo(f'loading {input_file} ...')
+        start_time = timeit.default_timer()
         
-        # Assign mapper.
-        mapper = item["mapper"]
+        # Assign mapper, set the transformation type, and reduce the mapper
+        # to date, geo and feature keys.
+        mapper = dict
+        with open(item["mapper"]) as f:
+            mapper = json.loads(f.read())
+        transform = mapper["meta"]
+        mapper = { k: mapper[k] for k in mapper.keys() & {"date", "geo", "feature"} }
 
-        # Call process without writing parquet files.
-        df, result_dict = process(input_file, mapper, geo, output_file = None, write_output=False)
+        # File type-specific pre-processing
+        ftype = transform["ftype"]
+        if ftype == "geotiff":
+            if transform["date"] == "":
+                d = None
+            else:
+                d = transform["date"]
 
-        # Combine dict to return single file.
-        renamed_col_dict = result_dict if not renamed_col_dict else {**renamed_col_dict, **result_dict}
+            df = raster2df(
+                InRaster = input_file,
+                feature_name = transform["feature_name"],
+                band = int(transform["band"] if "band" in transform and transform["band"] != "" else "0"),
+                nodataval = int(transform["null_val"]),
+                date = d,
+                band_name = transform["band_name"],
+                bands = transform["bands"] if "bands" in transform else None
+            )
+        elif ftype == 'excel':
+            df = pd.read_excel(input_file, transform['sheet'])
+        elif ftype != "csv":
+            df = netcdf2df(input_file)
+        else:
+            df = pd.read_csv(input_file)
 
+        df.reset_index(inplace=True, drop=True)
+        click.echo(f'{input_file} loading completed in {timeit.default_timer() - start_time} seconds')
+       
+        # Set the number of chunks based on chunk_size
+        chunks = 1 + (df.shape[0] // chunk_size) 
+        
+        # Entire dataset is loaded into df. Write in chunks to pkl files.
+        write_start = timeit.default_timer()
+        for i in range(1, chunks+1): 
+            filename = f'{data_temp_filename}.{i}.pkl'
+            stop_row = i*chunk_size
+            start_row = stop_row - chunk_size
+            df.iloc[start_row:stop_row,:].to_pickle(filename)
+          
+        click.echo(f'{input_file} pickle files writing completed in {timeit.default_timer() - write_start} seconds')
+        click.echo(f'processing {input_file} ...')
+        start_time = timeit.default_timer()
+        
+        # Iterate chunk tmp files and normalized each loaded df.
+        for i in range(1, chunks+1): 
+            read_filename = f'{data_temp_filename}.{i}.pkl' 
+            df_temp = pd.read_pickle(read_filename)
 
-        # Write dataframes to file instead of leaving in memory.
-        unused, input_filename = os.path.split(input_file)
+            ## Run normalizer.
+            norm_start_time = timeit.default_timer()
+            norm, result_dict = normalizer(df_temp, mapper, geo, gadm=gadm)
+            norm_stop_time = timeit.default_timer() - norm_start_time
 
-        ## Separate string values from others.
-        df['type'] = df[['value']].applymap(type)
-        df_str = df[df['type']==str]
-        df = df[df['type']!=str]
-        del(df_str['type'])
-        del(df['type'])
+            #click.echo(f'i: {i} chunk_size: {chunk_size} skiprows: {range(1, i*chunk_size)} iter_time:{iter_time} {iter_time  / chunk_size} {iter_time - first_iter_time}')
+            click.echo(f'i: {i} chunk_size: {chunk_size} skiprows: {range(1, i*chunk_size)} iter_time:{norm_stop_time}  diff:{first_norm_time - first_norm_time}')
+            
+            if first_norm_time == 0:
+                first_norm_time = norm_stop_time
 
-        ## Write separate parquet files. Write/read .csv results in wierd dtypes.
-        df.to_parquet(f"{input_filename}.parquet.gzip", compression="gzip")
-        temp_df_paths.append(f"{input_filename}.parquet.gzip")
-        if len(df_str) > 0:
-            df_str.to_parquet(f"{input_filename}_str.parquet.gzip", compression="gzip")
-            temp_df_str_paths.append(f"{input_filename}_str.parquet.gzip")
+            # Normalizer will add NaN for missing values, e.g. when appending
+            # dataframes with different columns. GADM will return None when geocoding
+            # but not finding the entity (e.g. admin3 for United States).
+            # Replace None with NaN for consistency.
+            norm.fillna(value=np.nan, inplace=True)
+
+            # In edge cases where the input files have different columns, keep 
+            # list of all columns for reading the tmp file.
+            for col in norm.columns.values.tolist():
+                if col not in df_columns:
+                    df_columns.append(col)
+            
+            if len(df_datatypes) == 0:
+                # Record datatypes of normalized df for setting on read.
+                norm = optimize_df_types(norm)
+                df_datatypes = dict(norm.dtypes)
+
+            #norm.to_csv(chunked_temp_filename, mode='a', index=False, header=False)
+            write_filename = f'{processed_temp_filename}.{input_file}.{i}.pkl'
+            norm.to_pickle(write_filename)
+
+            # A little cleanup, probably ineffective.
+            del(norm)
+            del(df_temp)
+
+            # Delete tmp files as they are read.
+            os.remove(read_filename)
+
+            # Combine dict to return single file.
+            renamed_col_dict = result_dict if not renamed_col_dict else {**renamed_col_dict, **result_dict}
+        
+        click.echo(f'{input_file} processing completed in {timeit.default_timer() - start_time} seconds')
 
 
     # Reassemble tmp files into a single (massive probably) df.
-    df = pd.DataFrame()
-    for temp_df_path in temp_df_paths:
-        # Read the temp df saved as a parquet.
-        temp_df = pd.read_parquet(temp_df_path)
-        # Append or assign to df.
-        df = temp_df if df.empty else df.append(temp_df)
-        # Remove the tmp file.
-        os.remove(temp_df_path)
-
-    # Do the same for any str parquets
-    df_str = pd.DataFrame()
-    for temp_df_str_path in temp_df_str_paths:
-        # Read the temp df saved as a parquet.
-        temp_df = pd.read_parquet(temp_df_str_path)
-        # Append or assign to df.
-        df_str = temp_df if df_str.empty else df_str.append(temp_df)
-        # Remove the tmp file.
-        os.remove(temp_df_str_path)
+    click.echo('reload tmp csv ...')
+    #df_final = pd.read_csv(chunked_temp_filename, names=df_columns)
+    start_time = timeit.default_timer()
+    df_final = pd.concat([pd.read_pickle(fl) for fl in [f'{processed_temp_filename}.{i}.pkl' for i in range(1, chunks+1)]])
+    df_final.reset_index(inplace=True, drop=True)
+    
+    # Clean up reassembly. 
+    for fl in glob(f'{processed_temp_filename}*'):
+        os.remove(fl)
+    
+    click.echo(f'reassembled dataframe in {timeit.default_timer() - start_time}')
+    click.echo(df_final.info(memory_usage="deep"))
+    click.echo(df_final.shape)
+    click.echo(df_final.head())
 
     # Write separate parquet files.
-    df.to_parquet(f"{output_file}.parquet.gzip", compression="gzip")
-    if not df_str.empty:
-        df_str.to_parquet(f"{output_file}_str.parquet.gzip", compression="gzip")
+    click.echo('writing parquet files ...')
+    df_final['type'] = df_final[['value']].applymap(type)
+    df_final_str = df_final[df_final['type']==str]
+    df_final = df_final[df_final['type']!=str]
+    del(df_final_str['type'])
+    del(df_final['type'])
+
+    df_final.to_parquet(f"{output_file}.parquet.gzip", compression="gzip")
+    if not df_final_str.empty:
+        df_final_str.to_parquet(f"{output_file}_str.parquet.gzip", compression="gzip")
     
-    return df.append(df_str), renamed_col_dict
+    click.echo('done.')
+    #return df_final.append(df_final_str), renamed_col_dict
 
 
 @cli.command()
@@ -193,4 +309,25 @@ def download():
 
 
 if __name__ == "__main__": 
-    cli()
+    #cli()
+    
+    if os.name == 'nt':
+        sep = '\\'
+    else:
+        sep = '/'
+        
+    inputs = "[{\"input_file\": \"inputs" + f"{sep}test1_input.csv\",\"mapper\": \"inputs{sep}test1_input.json\"" + "},{\"input_file\": \""
+    inputs = inputs + f"inputs{sep}test3_qualifies.csv\",\"mapper\": \"inputs{sep}test3_qualifies.json\"" + "}]"
+
+
+    inputs = "[ {\"input_file\":\"Test1_2D-Q.nc\", "
+    inputs = inputs + "\"mapper\":\"mapper_e489d023-58c3-4544-8ae1-bb9cfa987e23.json\"}]"
+
+    inputs = "[ {\"input_file\":\"lpjml_sample.nc\", "
+    inputs = inputs + "\"mapper\":\"lpml_mapper.json\"}]"
+
+
+    df, dict = causemosify_multi(inputs, geo='admin2', output_file='testing')
+    print('\n', df.shape)
+    print(df.head())
+    

--- a/mixmasta/cli.py
+++ b/mixmasta/cli.py
@@ -5,12 +5,11 @@ from datetime import datetime
 import click
 import pandas as pd
 
-#from .download import download_and_clean
-#from .mixmasta import geocode, netcdf2df, process, raster2df
+from .download import download_and_clean
+from .mixmasta import geocode, netcdf2df, process, raster2df, normalizer, optimize_df_types, mixdata
 
-from download import download_and_clean
-from mixmasta import geocode, netcdf2df, process, raster2df, normalizer, optimize_df_types
-from mixmasta import mixdata
+#from download import download_and_clean
+#from mixmasta import geocode, netcdf2df, process, raster2df, normalizer, optimize_df_types, mixdata
 
 from glob import glob
 import numpy as np
@@ -19,9 +18,150 @@ import json
 import timeit
 
 
+# Constants
+CHUNK_SIZE = 100000
+DATA_TEMP_FILENAME = 'causmosify_multi_tmp'
+PROCESSED_TEMP_FILENAME = 'processed_tmp'
+
 @click.group()
 def cli():
     pass
+
+
+def chunk_normalize(input_file: str, mapper: dict, renamed_col_dict: dict, geo: str, gadm, df_geocode: pd.DataFrame) -> dict:
+    """
+        Description
+        ----------
+            Normalize input_file in chunks written to pkl files.
+
+        Parameters
+        ----------
+            input_file: str
+                Filename of file to normalize.
+            mapper: dict
+                Mapper dict for filename.
+            renamed_col_dict: dict
+                Dict maintained to track columns renamed during normalize()
+            gadm: 
+                GADM geopandas object passed as param so it is loaded only once
+            df_geocode: pd.DataFrame
+                lat/lng geocode library to cache geocoding.
+        
+        Returns
+        -------
+            dict: 
+                updated renamed_col_dict
+
+    """
+
+    df_datatypes = {}
+    df_columns = []
+    first_norm_time = 0
+
+    click.echo(f'\nLoading {input_file} ...')
+    start_time = timeit.default_timer()
+    
+    # Set the transformation type, and reduce the mapper to date, geo and feature keys.
+    transform = mapper["meta"]
+    mapper = { k: mapper[k] for k in mapper.keys() & {"date", "geo", "feature"} }
+
+    # File type-specific pre-processing
+    ftype = transform["ftype"]
+    if ftype == "geotiff":
+        if transform["date"] == "":
+            d = None
+        else:
+            d = transform["date"]
+
+        df = raster2df(
+            InRaster = input_file,
+            feature_name = transform["feature_name"],
+            band = int(transform["band"] if "band" in transform and transform["band"] != "" else "0"),
+            nodataval = int(transform["null_val"]),
+            date = d,
+            band_name = transform["band_name"],
+            bands = transform["bands"] if "bands" in transform else None
+        )
+    elif ftype == 'excel':
+        df = pd.read_excel(input_file, transform['sheet'])
+    elif ftype != "csv":
+        df = netcdf2df(input_file)
+    else:
+        df = pd.read_csv(input_file)
+
+    df.reset_index(inplace=True, drop=True)
+    
+    # Set the number of chunks based on CHUNK_SIZE
+    chunks = 1 + (df.shape[0] // CHUNK_SIZE) 
+    
+    # Entire dataset is loaded into df. Write in chunks to pkl files.
+    for i in range(1, chunks+1): 
+        filename = f'{DATA_TEMP_FILENAME}.{i}.pkl'
+        stop_row = i*CHUNK_SIZE
+        start_row = stop_row - CHUNK_SIZE
+        df.iloc[start_row:stop_row,:].to_pickle(filename)
+        
+    click.echo(f'Processing {input_file} ...')
+    start_time = timeit.default_timer()
+    
+    # Iterate chunk tmp files and normalized each loaded df.
+    for i in range(1, chunks+1): 
+        read_filename = f'{DATA_TEMP_FILENAME}.{i}.pkl' 
+        df_temp = pd.read_pickle(read_filename)
+
+        ## Run normalizer.
+        norm_start_time = timeit.default_timer()
+        norm, result_dict, df_geocode  = normalizer(df_temp, mapper, geo, gadm=gadm, df_geocode=df_geocode)
+   
+        # Normalizer will add NaN for missing values, e.g. when appending
+        # dataframes with different columns. GADM will return None when geocoding
+        # but not finding the entity (e.g. admin3 for United States).
+        # Replace None with NaN for consistency.
+        norm.fillna(value=np.nan, inplace=True)
+
+        # In edge cases where the input files have different columns, keep 
+        # list of all columns for reading the tmp file.
+        for col in norm.columns.values.tolist():
+            if col not in df_columns:
+                df_columns.append(col)
+        
+        if len(df_datatypes) == 0:
+            # Record datatypes of normalized df for setting on read.
+            norm = optimize_df_types(norm)
+            df_datatypes = dict(norm.dtypes)
+
+        #norm.to_csv(chunked_temp_filename, mode='a', index=False, header=False)
+        write_filename = f'{PROCESSED_TEMP_FILENAME}.{os.path.basename(input_file)}.{i}.pkl'
+        norm.to_pickle(write_filename)
+
+        # A little cleanup, probably ineffective.
+        del(norm)
+        del(df_temp)
+
+        # Delete tmp files as they are read.
+        os.remove(read_filename)
+
+        # Combine dict to return single file.
+        renamed_col_dict = result_dict if not renamed_col_dict else {**renamed_col_dict, **result_dict}
+
+    click.echo(f'{input_file} processing completed in {timeit.default_timer() - start_time} seconds')
+
+    return renamed_col_dict
+
+
+def get_gadm(geo: str):
+    # Cache GADM for normalize() loops.
+    md = mixdata()
+    if geo.lower() == 'admin2':
+        click.echo('Loading GADM2 ...')
+        md.load_gadm2()
+        gadm = md.gadm2
+    else:
+        click.echo('Loading GADM3 ...')
+        md.load_gadm3()
+        gadm = md.gadm3
+
+    return gadm
 
 
 def glob_input_file(input_file: str) -> str:
@@ -39,6 +179,7 @@ def glob_input_file(input_file: str) -> str:
             input_file = input_file
     return input_file
 
+
 @cli.command()
 @click.option("--input_file", type=str, default=None)
 @click.option("--mapper", type=str, default=None)
@@ -49,181 +190,23 @@ def causemosify(input_file, mapper, geo: str, output_file):
     click.echo("Causemosifying data...")
 
     input_file =  glob_input_file(input_file)
-    return process(input_file, mapper, geo, output_file)
+    gadm = get_gadm(geo)
+    with open(mapper) as f:
+        mapper = json.loads(f.read())
 
+    # Chunk normalized, return the renamed_dict. The data will be read from pkl
+    # files beelow.
+    renamed_col_dict = chunk_normalize(input_file, mapper, {}, geo, gadm)
 
-#@cli.command()
-#@click.option("--inputs", type=str, default=None)
-#@click.option("--geo", type=str, default=None)
-#@click.option("--output-file", type=str, default="mixmasta_output")
-def causemosify_multi(inputs, geo, output_file):
-    """Process multiple input files to generate a single CauseMos compliant dataset."""
-
-    """
-        Usurps mixmasta.process() to control memory use.
-    
-        --inputs is one long gnarly string with interior quotations escaped e.g.:
-        "[{\"input_file\": \"build-a-date-qualifier_*.csv\",
-                \"mapper\": \"build-a-date-qualifier.json\"}]"  
-    
-    
-    """
-
-    input_array = json.loads(inputs)   
-    click.echo(f"Causemosifying {len(input_array)} file(s) ...")
-    
-    # Cache GADM for normalize() loops.
-    md = mixdata()
-    if geo.lower() == 'admin2':
-        click.echo('Loading GADM2 ...')
-        md.load_gadm2()
-        gadm = md.gadm2
-    else:
-        click.echo('Loading GADM3 ...')
-        md.load_gadm3()
-        gadm = md.gadm3
-
-    # Setup variables.
-    renamed_col_dict = {}
-    df_datatypes = {}
-    df_columns = []
-    chunk_size = 100000
-    data_temp_filename = 'causmosify_multi_tmp'
-    processed_temp_filename = 'processed_tmp'
-    first_norm_time = 0
-
-    # Delete any previous tmp files.
-    for fl in glob(f'{processed_temp_filename}*'):
-        os.remove(fl)
-    
-    for fl in glob(f'{data_temp_filename}*'):
-        os.remove(fl)
-  
-    # Iterate each item in the --inputs JSON.
-    for item in input_array:
-        # Handle filename wildcards with glob_input_file().
-        input_file =  glob_input_file(item["input_file"])
-        click.echo(f'loading {input_file} ...')
-        start_time = timeit.default_timer()
-        
-        # Assign mapper, set the transformation type, and reduce the mapper
-        # to date, geo and feature keys.
-        mapper = dict
-        with open(item["mapper"]) as f:
-            mapper = json.loads(f.read())
-        transform = mapper["meta"]
-        mapper = { k: mapper[k] for k in mapper.keys() & {"date", "geo", "feature"} }
-
-        # File type-specific pre-processing
-        ftype = transform["ftype"]
-        if ftype == "geotiff":
-            if transform["date"] == "":
-                d = None
-            else:
-                d = transform["date"]
-
-            df = raster2df(
-                InRaster = input_file,
-                feature_name = transform["feature_name"],
-                band = int(transform["band"] if "band" in transform and transform["band"] != "" else "0"),
-                nodataval = int(transform["null_val"]),
-                date = d,
-                band_name = transform["band_name"],
-                bands = transform["bands"] if "bands" in transform else None
-            )
-        elif ftype == 'excel':
-            df = pd.read_excel(input_file, transform['sheet'])
-        elif ftype != "csv":
-            df = netcdf2df(input_file)
-        else:
-            df = pd.read_csv(input_file)
-
-        df.reset_index(inplace=True, drop=True)
-        click.echo(f'{input_file} loading completed in {timeit.default_timer() - start_time} seconds')
-       
-        # Set the number of chunks based on chunk_size
-        chunks = 1 + (df.shape[0] // chunk_size) 
-        
-        # Entire dataset is loaded into df. Write in chunks to pkl files.
-        write_start = timeit.default_timer()
-        for i in range(1, chunks+1): 
-            filename = f'{data_temp_filename}.{i}.pkl'
-            stop_row = i*chunk_size
-            start_row = stop_row - chunk_size
-            df.iloc[start_row:stop_row,:].to_pickle(filename)
-          
-        click.echo(f'{input_file} pickle files writing completed in {timeit.default_timer() - write_start} seconds')
-        click.echo(f'processing {input_file} ...')
-        start_time = timeit.default_timer()
-        
-        # Iterate chunk tmp files and normalized each loaded df.
-        for i in range(1, chunks+1): 
-            read_filename = f'{data_temp_filename}.{i}.pkl' 
-            df_temp = pd.read_pickle(read_filename)
-
-            ## Run normalizer.
-            norm_start_time = timeit.default_timer()
-            norm, result_dict = normalizer(df_temp, mapper, geo, gadm=gadm)
-            norm_stop_time = timeit.default_timer() - norm_start_time
-
-            #click.echo(f'i: {i} chunk_size: {chunk_size} skiprows: {range(1, i*chunk_size)} iter_time:{iter_time} {iter_time  / chunk_size} {iter_time - first_iter_time}')
-            click.echo(f'i: {i} chunk_size: {chunk_size} skiprows: {range(1, i*chunk_size)} iter_time:{norm_stop_time}  diff:{first_norm_time - first_norm_time}')
-            
-            if first_norm_time == 0:
-                first_norm_time = norm_stop_time
-
-            # Normalizer will add NaN for missing values, e.g. when appending
-            # dataframes with different columns. GADM will return None when geocoding
-            # but not finding the entity (e.g. admin3 for United States).
-            # Replace None with NaN for consistency.
-            norm.fillna(value=np.nan, inplace=True)
-
-            # In edge cases where the input files have different columns, keep 
-            # list of all columns for reading the tmp file.
-            for col in norm.columns.values.tolist():
-                if col not in df_columns:
-                    df_columns.append(col)
-            
-            if len(df_datatypes) == 0:
-                # Record datatypes of normalized df for setting on read.
-                norm = optimize_df_types(norm)
-                df_datatypes = dict(norm.dtypes)
-
-            #norm.to_csv(chunked_temp_filename, mode='a', index=False, header=False)
-            write_filename = f'{processed_temp_filename}.{input_file}.{i}.pkl'
-            norm.to_pickle(write_filename)
-
-            # A little cleanup, probably ineffective.
-            del(norm)
-            del(df_temp)
-
-            # Delete tmp files as they are read.
-            os.remove(read_filename)
-
-            # Combine dict to return single file.
-            renamed_col_dict = result_dict if not renamed_col_dict else {**renamed_col_dict, **result_dict}
-        
-        click.echo(f'{input_file} processing completed in {timeit.default_timer() - start_time} seconds')
-
-
-    # Reassemble tmp files into a single (massive probably) df.
-    click.echo('reload tmp csv ...')
-    #df_final = pd.read_csv(chunked_temp_filename, names=df_columns)
-    start_time = timeit.default_timer()
-    df_final = pd.concat([pd.read_pickle(fl) for fl in [f'{processed_temp_filename}.{i}.pkl' for i in range(1, chunks+1)]])
+    # Reassemble tmp pkl files.
+    df_final = pd.concat([pd.read_pickle(fl) for fl in glob(f'{PROCESSED_TEMP_FILENAME}.*.pkl')])
     df_final.reset_index(inplace=True, drop=True)
     
     # Clean up reassembly. 
-    for fl in glob(f'{processed_temp_filename}*'):
+    for fl in glob(f'{PROCESSED_TEMP_FILENAME}*'):
         os.remove(fl)
     
-    click.echo(f'reassembled dataframe in {timeit.default_timer() - start_time}')
-    click.echo(df_final.info(memory_usage="deep"))
-    click.echo(df_final.shape)
-    click.echo(df_final.head())
-
     # Write separate parquet files.
-    click.echo('writing parquet files ...')
     df_final['type'] = df_final[['value']].applymap(type)
     df_final_str = df_final[df_final['type']==str]
     df_final = df_final[df_final['type']!=str]
@@ -234,8 +217,92 @@ def causemosify_multi(inputs, geo, output_file):
     if not df_final_str.empty:
         df_final_str.to_parquet(f"{output_file}_str.parquet.gzip", compression="gzip")
     
-    click.echo('done.')
-    #return df_final.append(df_final_str), renamed_col_dict
+    # Rebuild and reduce memory size of returned dataframe.
+    df_final = df_final.append(df_final_str)
+    df_final = optimize_df_types(df_final)
+    df_final.reset_index(inplace=True, drop=True)
+
+    return df_final, renamed_col_dict
+    
+
+@cli.command()
+@click.option("--inputs", type=str, default=None)
+@click.option("--geo", type=str, default=None)
+@click.option("--output-file", type=str, default="mixmasta_output")
+def causemosify_multi(inputs, geo, output_file):
+    """Process multiple input files to generate a single CauseMos compliant dataset."""
+
+    """
+        Description
+        -----------
+        Usurps mixmasta.process() to control memory use.
+    
+        --inputs is one long gnarly string with interior quotations escaped e.g.:
+        "[{\"input_file\": \"build-a-date-qualifier_*.csv\",
+                \"mapper\": \"build-a-date-qualifier.json\"}]"  
+    
+
+        Writes separate parquet files for each input file.
+    """
+
+    input_array = json.loads(inputs)   
+    click.echo(f"Causemosifying {len(input_array)} file(s) ...")
+    
+    # Cache GADM for normalize() loops.
+    gadm = get_gadm(geo)
+
+    # Setup variables.
+    renamed_col_dict = {}
+    df_geocode = pd.DataFrame()
+
+    # Delete any previous tmp files.
+    for fl in glob(f'{PROCESSED_TEMP_FILENAME}*'):
+        os.remove(fl)
+    
+    for fl in glob(f'{DATA_TEMP_FILENAME}*'):
+        os.remove(fl)
+  
+    # Iterate each item_item in the --inputs JSON.
+    item_counter = 0
+    for item_item in input_array:        
+        item_counter += 1
+        # Handle filename wildcards with glob_input_file().
+        input_file =  glob_input_file(item_item["input_file"])
+       
+        with open(item_item ["mapper"]) as f:
+            mapper = json.loads(f.read())
+
+        renamed_col_dict = chunk_normalize(input_file = input_file, 
+            mapper = mapper, 
+            renamed_col_dict=renamed_col_dict, 
+            geo=geo,
+            gadm=gadm,
+            df_geocode=df_geocode)
+
+        # Reassemble tmp files into df ...)
+        df_final = pd.concat([pd.read_pickle(fl) for fl in glob(f'{PROCESSED_TEMP_FILENAME}.*.pkl')])
+        df_final.reset_index(inplace=True, drop=True)
+    
+        # ... then clean up reassembly. 
+        for fl in glob(f'{PROCESSED_TEMP_FILENAME}*'):
+            os.remove(fl)
+       
+        # Write separate parquet files depending on type of value column ...
+        # ... by creating a separting df for value col of type str ...
+        df_final['type'] = df_final[['value']].applymap(type)
+        df_final_str = df_final[df_final['type']==str]
+        df_final = df_final[df_final['type']!=str]
+        del(df_final_str['type'])
+        del(df_final['type'])
+
+        # ... now write the files.
+        df_final.to_parquet(f"{output_file}.{item_counter}.parquet.gzip", compression="gzip")
+        if not df_final_str.empty:
+            df_final_str.to_parquet(f"{output_file}_str.{item_counter}.parquet.gzip", compression="gzip")
+    
+    # Causemosify-multi does not return the dataframe or dict.
+
+    click.echo('Done.')
 
 
 @cli.command()
@@ -309,25 +376,33 @@ def download():
 
 
 if __name__ == "__main__": 
-    #cli()
     
+    cli()
+    '''
+    Testing
     if os.name == 'nt':
         sep = '\\'
     else:
         sep = '/'
         
+
+    inputs = "[ {\"input_file\":\"Test1_2D-Q.nc\", "
+    inputs = inputs + "\"mapper\":\"mapper_e489d023-58c3-4544-8ae1-bb9cfa987e23.json\"},"
+
+    inputs = inputs + "{\"input_file\":\"Test1_2D-d-flood.nc\", \"mapper\":\"mapper_25d1d6ab-1e74-4084-8c18-692e6542aa49.json\"},"
+    inputs = inputs + "{\"input_file\":\"Test1_2D-d.nc\", \"mapper\":\"mapper_7302d901-85b8-4fab-a3b2-b9e0b9646458.json\"},"
+    inputs = inputs + "{\"input_file\":\"Test1_2D-u.nc\", \"mapper\":\"mapper_c925ad6e-5275-4a2c-b288-ba7c450a4b8f.json\"}"
+    
+    inputs = inputs + "]"
+
+    #inputs = "[ {\"input_file\":\"lpjml_sample.nc\", "
+    #inputs = inputs + "\"mapper\":\"lpml_mapper.json\"}]"
+
     inputs = "[{\"input_file\": \"inputs" + f"{sep}test1_input.csv\",\"mapper\": \"inputs{sep}test1_input.json\"" + "},{\"input_file\": \""
     inputs = inputs + f"inputs{sep}test3_qualifies.csv\",\"mapper\": \"inputs{sep}test3_qualifies.json\"" + "}]"
 
 
-    inputs = "[ {\"input_file\":\"Test1_2D-Q.nc\", "
-    inputs = inputs + "\"mapper\":\"mapper_e489d023-58c3-4544-8ae1-bb9cfa987e23.json\"}]"
 
-    inputs = "[ {\"input_file\":\"lpjml_sample.nc\", "
-    inputs = inputs + "\"mapper\":\"lpml_mapper.json\"}]"
-
-
-    df, dict = causemosify_multi(inputs, geo='admin2', output_file='testing')
-    print('\n', df.shape)
-    print(df.head())
-    
+    causemosify_multi(inputs, geo='admin2', output_file='testing')
+    #causemosify(input_file="lpjml_sample.nc", mapper="lpml_mapper.json", geo="admin2", output_file="output.tmp")
+    '''

--- a/mixmasta/mixmasta.py
+++ b/mixmasta/mixmasta.py
@@ -601,7 +601,6 @@ def netcdf2df(netcdf: str) -> pd.DataFrame:
         The resultant dataframe
     """
     try:        
-        #import netCDF4 as nc
         ds = xr.open_dataset(netcdf)
     except:
         raise AssertionError(f"improperly formatted netCDF file ({netcdf})")
@@ -1132,8 +1131,6 @@ def process(fp: str, mp: str, admin: str, output_file: str, write_output = True,
     else:
         df = pd.read_csv(fp)
 
-    #print('df info memory\n', df.info(memory_usage='deep'))
-
     ## Make mapper contain only keys for date, geo, and feature.
     mapper = { k: mapper[k] for k in mapper.keys() & {"date", "geo", "feature"} }
 
@@ -1143,28 +1140,6 @@ def process(fp: str, mp: str, admin: str, output_file: str, write_output = True,
     df = optimize_df_types(df)
     df.reset_index(inplace=True, drop=True)
 
-    """
-    # --------- new
-    df_array = np.array_split(df, 3)
-    norm = DataFrame()
-    renamed_col_dict = {}
-
-    for df_a in df_array:
-        df_norm, df_renamed_col_dict = normalizer(df_a, mapper, admin, gadm=gadm)
-            
-        norm = df_norm if norm.empty else norm.append(df_norm, ignore_index=True)
-        renamed_col_dict.update(df_renamed_col_dict)
-
-
-    cols = ['timestamp','country','admin1','admin2','admin3','lat','lng','feature','value']
-    norm.sort_values(by=cols, inplace=True)
-    norm.reset_index(drop=True, inplace=True)
-    print('norm.shape: ', norm.shape)
-    print(norm.head())
-    print(norm.tail())
-
-    # --------- end new
-    """
     ## Run normailizer.
     norm, renamed_col_dict = normalizer(df, mapper, admin, gadm=gadm)
 

--- a/tests/test_mixmasta.py
+++ b/tests/test_mixmasta.py
@@ -236,8 +236,10 @@ class TestMixmaster(unittest.TestCase):
         self.assertEqual(result.returncode, 0)
         
 
-        ## Compare parquet file.
-        df = pd.read_parquet(f"outputs{sep}unittests.parquet.gzip")
+        ## Compare parquet files.
+        df1 = pd.read_parquet(f"outputs{sep}unittests.1.parquet.gzip")
+        df2 = pd.read_parquet(f"outputs{sep}unittests.2.parquet.gzip")
+        df = df1.append(df2)
         output_df = pd.read_parquet(f"outputs{sep}test5.parquet.gzip")
 
         # Sort both data frames and reindex for comparison,.
@@ -254,7 +256,7 @@ class TestMixmaster(unittest.TestCase):
         assert_frame_equal(df, output_df, check_categorical = False)
 
         ## Compare str.parquet file.
-        df = pd.read_parquet(f"outputs{sep}unittests_str.parquet.gzip")
+        df = pd.read_parquet(f"outputs{sep}unittests_str.2.parquet.gzip")
         output_df = pd.read_parquet(f"outputs{sep}test5_str.parquet.gzip")
 
         # Sort both data frames and reindex for comparison,.

--- a/tests/test_mixmasta.py
+++ b/tests/test_mixmasta.py
@@ -8,7 +8,7 @@ import warnings
 
 from click.testing import CliRunner
 import subprocess
-
+import logging
 import json
 from mixmasta import cli, mixmasta
 from pandas.util.testing import assert_frame_equal, assert_dict_equal
@@ -20,6 +20,8 @@ if os.name == 'nt':
     sep = '\\'
 else:
     sep = '/'
+
+logger = logging.getLogger(__name__)
 
 class TestMixmaster(unittest.TestCase):
     """Tests for `mixmasta` package."""
@@ -229,7 +231,10 @@ class TestMixmaster(unittest.TestCase):
         inputs = "--inputs=[{\"input_file\": \"inputs" + f"{sep}test1_input.csv\",\"mapper\": \"inputs{sep}test1_input.json\"" + "},{\"input_file\": \""
         inputs = inputs + f"inputs{sep}test3_qualifies.csv\",\"mapper\": \"inputs{sep}test3_qualifies.json\"" + "}]"
         result = subprocess.run(['mixmasta', "causemosify-multi", inputs, "--geo=admin2", f"--output-file=outputs{sep}unittests"], capture_output=True, encoding='utf-8')
+        if (result.returncode != 0):
+            print(result)
         self.assertEqual(result.returncode, 0)
+        
 
         ## Compare parquet file.
         df = pd.read_parquet(f"outputs{sep}unittests.parquet.gzip")
@@ -241,6 +246,9 @@ class TestMixmaster(unittest.TestCase):
         output_df.sort_values(by=cols, inplace=True)
         df.reset_index(drop=True, inplace=True)
         output_df.reset_index(drop =True, inplace=True)
+
+        logger.info(df.shape)
+        logger.info(output_df.shape)
 
         # Assertion
         assert_frame_equal(df, output_df, check_categorical = False)


### PR DESCRIPTION
### Description

- address #54 
-  does not address netCDFs specifically, but modifies `cli.py` `causemosify-multi()` to write dataframes to parquet files while looping
- parquets require the extra step of separating str type columns, but csv read/write results in wrong dtypes.
- passed unit testing

### Todo

- benchmarking?