### PR TITLE
 If timestamp is a column, but not primary #65 error

### DIFF
--- a/mixmasta/mixmasta.py
+++ b/mixmasta/mixmasta.py
@@ -777,6 +777,7 @@ def normalizer(df: pd.DataFrame, mapper: dict, admin: str, gadm: gpd.GeoDataFram
                 # column_name meaning is not lost.
                 if not primary_time_cols and not "timestamp" in df.columns:
                     df.rename(columns={kk: "timestamp"}, inplace=True)
+                    staple_col_name ="timestamp"
                     renamed_col_dict[ staple_col_name ] = [kk]
                 # All not primary_time, not associated_columns fields are pushed to features.
                 features.append(kk)


### PR DESCRIPTION
### Description

- Addresses #61 
- and #65 

### Notes
- #61 appears to already have been implemented in Travis' original code.
- `staple_col_name` is assigned to "timestamp" prior to adding to changed-column dictionary used by SpaceTag
### Testing
- passed existing unit tests

