### PR TITLE
removed mixmasta download and added manual download near top

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,6 +3,15 @@ RUN apt-get update && \
       apt-get -y install sudo
 RUN apt-get install -y software-properties-common
 RUN apt-get update
+
+RUN apt-get install wget unzip
+RUN wget https://jataware-world-modelers.s3.amazonaws.com/gadm/gadm36_2.feather.zip 
+RUN wget https://jataware-world-modelers.s3.amazonaws.com/gadm/gadm36_3.feather.zip
+RUN mkdir ~/mixmasta_data && \
+      unzip gadm36_2.feather.zip -d ~/mixmasta_data/ && \
+      unzip gadm36_3.feather.zip -d ~/mixmasta_data/ && \
+      rm gadm36_?.feather.zip
+
 RUN add-apt-repository ppa:ubuntugis/ubuntugis-unstable
 RUN apt-get update
 RUN apt-get install -y python3.8-dev
@@ -10,6 +19,7 @@ RUN apt-get install -y gdal-bin
 RUN apt-get install -y libgdal-dev
 RUN apt-get install -y python3-pip
 RUN apt install -y python3-rtree
+
 ENV CPLUS_INCLUDE_PATH=/usr/include/gdal
 ENV C_INCLUDE_PATH=/usr/include/gdal
 
@@ -20,6 +30,6 @@ COPY requirements.txt /requirements.txt
 RUN pip3 install -r requirements.txt
 COPY . /
 RUN python3 setup.py install
-RUN mixmasta download
+#RUN mixmasta download
 
 ENTRYPOINT ["mixmasta"]


### PR DESCRIPTION
### Description
- Addresses #75 
- Added new code after `software-properties-common` is installed at top.
- Commented out `mixmasta download` at bottoom.

### Notes 
Seems a bit wordy to download and unzip; it is possible it can be optimized:
```
RUN apt-get install wget unzip
RUN wget https://jataware-world-modelers.s3.amazonaws.com/gadm/gadm36_2.feather.zip 
RUN wget https://jataware-world-modelers.s3.amazonaws.com/gadm/gadm36_3.feather.zip
RUN mkdir ~/mixmasta_data && \
      unzip gadm36_2.feather.zip -d ~/mixmasta_data/ && \
      unzip gadm36_3.feather.zip -d ~/mixmasta_data/ && \
      rm gadm36_?.feather.zip
```

### Testing
- Built container and ran `unittests` successfully: 
```
root@e9f445008815:/workspaces/mixmasta# cd tests
root@e9f445008815:/workspaces/mixmasta/tests# python3 -m unittest test_mixmasta.py -v
```